### PR TITLE
Use -P rather than -O when passing options

### DIFF
--- a/src/KzykHys/Pygments/Pygments.php
+++ b/src/KzykHys/Pygments/Pygments.php
@@ -53,13 +53,9 @@ class Pygments
         }
 
         if (count($options)) {
-            $arg = array();
-
             foreach ($options as $key => $value) {
-                $arg[] = sprintf('%s=%s', $key, $value);
+                $builder->add('-P')->add(sprintf('%s=%s', $key, $value));
             }
-
-            $builder->add('-O')->add(implode(',', $arg));
         }
 
         $process = $builder->getProcess()->setStdin($code);


### PR DESCRIPTION
To allow option values containing commas.
-P is new in Pygments 0.9.
http://pygments.org/docs/cmdline/#options-and-filters

Fixes #4.
