### PR TITLE
Upper bound the version ranges of the dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.3.2",
-        "symfony/process": ">=2.3"
+        "symfony/process": "~2.3"
     },
     "require-dev": {
-        "symfony/finder": ">=2.3"
+        "symfony/finder": "~2.3"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This avoids pulling in breaking releases without first
explicitly defining compatibility. See http://semver.org/
